### PR TITLE
Fix: menu and color

### DIFF
--- a/assets/scss/slate/_variables.scss
+++ b/assets/scss/slate/_variables.scss
@@ -1,7 +1,7 @@
 @import 'docuapi_overrides';
 
 .content {
-  // prevent clearing of higlight divs
+  // prevent clearing of highlight divs
   &>div.highlight {
     clear:none;
   }
@@ -9,18 +9,18 @@
 
 // BACKGROUND COLORS
 ////////////////////
-$nav-bg: #25283D !default;
-$examples-bg: #25283D  !default;
-$code-bg: #783F8E !default;
+$nav-bg: #2E3336 !default;
+$examples-bg: #2E3336 !default;
+$code-bg: #1E2224 !default;
 $code-annotation-bg: #191D1F !default;
 $nav-subitem-bg: #1E2224 !default;
 $nav-active-bg: #0F75D4 !default;
 $nav-active-parent-bg: #1E2224 !default; // parent links of the current section
 $lang-select-border: #000 !default;
 $lang-select-bg: #1E2224 !default;
-$lang-select-active-bg: #3E92CC !default; // feel free to change this to blue or something
+$lang-select-active-bg: $examples-bg !default; // feel free to change this to blue or something
 $lang-select-pressed-bg: #111 !default; // color of language tab bg when mouse is pressed
-$main-bg: #FFFAFF !default;
+$main-bg: #F3F7F9 !default;
 $aside-notice-bg: #8fbcd4 !default;
 $aside-warning-bg: #c97a7e !default;
 $aside-success-bg: #6ac174 !default;

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,7 +8,16 @@
     <ul id="toc" class="toc-list-h1">
         {{ $headers := partial "funcs/toc_from_pages" .Site.RegularPages }}
         {{ range $headers }}
-        <a href="#{{ .title | anchorize }}" class="toc-h{{ .level }} toc-link" data-title="{{ .title }}">{{ .title }}</a>
-        {{ end }}
+            <li>
+                <a href="#{{ .title | anchorize }}" class="toc-h{{ .level }} toc-link" data-title="{{ .title }}">{{ .title }}</a>
+                {{if .sub }}
+                    <ul class="toc-list-h2">
+                        {{range .sub}}
+                            <li><a href="#{{ .title | anchorize }}" class="toc-h{{ .level }} toc-link" data-title="{{ .title }}">{{ .title }}</a></li>
+                        {{end}}
+                    </ul>
+                {{end}}
+            </li>
+        {{end}}
     </ul>
 {{ end }}

--- a/layouts/partials/funcs/extract_js_requirements.html
+++ b/layouts/partials/funcs/extract_js_requirements.html
@@ -4,7 +4,7 @@
 {{ range $req }}
     {{ $imp := strings.TrimPrefix "//= require" . }}
     {{ $imp = trim $imp " " }}
-    {{ $imp = printf "%s.js" (path.Join $dir $imp) }}
+    {{ $imp = printf "/%s.js" (path.Join $dir $imp) }}
     {{ if not ($.visited.Get $imp) }}
         {{ $.visited.Set $imp true }}
         {{ $nested := resources.Get $imp }}

--- a/layouts/partials/funcs/toc_from_pages.html
+++ b/layouts/partials/funcs/toc_from_pages.html
@@ -1,12 +1,32 @@
 {{ $toc := slice }}
 {{ range . }}
-{{ $headers := findRE "<h\\d.*?>(.|\n)*?</h\\d>" .Content }}
-{{ range $headers }}
-{{ $level :=  int (substr . 2 1) }}
-{{ if le $level 2 }}
-{{ $header := . | replaceRE "</?h\\d.*?>" "" | htmlUnescape | safeHTML }}
-{{ $toc = $toc | append (dict "level" $level "title" $header ) }}
-{{ end }}
-{{ end }}
+    {{ $previousH1 := dict}}
+    {{ $previousLevel := 0 }}
+    {{ $h2s := slice }}
+
+    {{ $headers := findRE "<h\\d.*?>(.|\n)*?</h\\d>" .Content }}
+    {{ range $headers }}
+        {{ $level := int (substr . 2 1) }}
+        {{ if le $level 2 }}
+            {{ $title := . | replaceRE "</?h\\d.*?>" "" | htmlUnescape | safeHTML }}
+            {{ $item := dict "level" $level "title" $title }}
+
+            {{if eq $level 1 }}
+                {{if ne $previousLevel 0 }}
+                    {{ $tocItem := merge $previousH1 (dict "sub" $h2s)}}
+                    {{ $toc = $toc | append $tocItem }}
+                    {{ $h2s = slice }}
+                {{end}}
+                {{ $previousH1 = $item }}
+            {{else}}
+                {{ $h2s = $h2s | append $item}}
+            {{end}}
+            {{ $previousLevel = $level }}
+        {{ end }}
+    {{ end }}
+    {{if ne $previousLevel 0}}
+        {{ $item := merge $previousH1 (dict "sub" $h2s)}}
+        {{ $toc = $toc | append $item }}
+    {{end}}
 {{ end }}
 {{ return $toc }}


### PR DESCRIPTION
- use same color as [default slate color](https://lord.github.io/slate/#kittens)
- fix h1 and h2 behaviors

Before the PR:
![before](https://user-images.githubusercontent.com/5674651/63115480-90187680-bf97-11e9-8d4e-777847c4064e.png)

After the PR:
![Screenshot_2019-08-15 All – PRM - Pull Request Manager](https://user-images.githubusercontent.com/5674651/63127858-d11e8400-bfb3-11e9-92e0-abafe452db79.png)


Related to #28 