### PR TITLE
fix npm version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "engines": {
     "node": ">=8.9.0",
-    "npm": ">6"
+    "npm": ">=6"
   },
   "author": "bep",
   "license": "Apache-2.0",


### PR DESCRIPTION
I believe that npm should be `>=6` instead of `>6`.