### PR TITLE
Multiple languages by tab

### DIFF
--- a/assets/js/slate/app/_lang.js
+++ b/assets/js/slate/app/_lang.js
@@ -36,8 +36,11 @@ under the License.
       $(codeSelectorPrefix + languages[i]).parentsUntil(".highlight").hide();
       $(".lang-specific." + languages[i]).hide();
     }
-    $(codeSelectorPrefix + language).parentsUntil(".highlight").show();
-    $(".lang-specific." + language).parentsUntil(".highlight").show();
+    var languagesToKeep = JSON.parse(document.activeElement.getAttribute('data-with' + language));
+    for (var i=0; i < languagesToKeep.length; i++) {
+      $(codeSelectorPrefix + languagesToKeep[i]).parentsUntil(".highlight").show();
+      $(".lang-specific." + languagesToKeep[i]).parentsUntil(".highlight").show();
+    }
 
     // scroll to the new location of the position
     if ($(window.location.hash).get(0)) {

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -45,6 +45,7 @@ name = "Python"
 [[params.language_tabs]]
 key = "javascript"
 name = "Javascript"
+otherlangs = "java"
 
 #Languages 
 [languages]

--- a/exampleSite/content/kittens.md
+++ b/exampleSite/content/kittens.md
@@ -38,6 +38,15 @@ curl "http://example.com/api/kittens"
   -H "Authorization: meowmeowmeow"
 ```
 
+```java
+public class MyClass {
+  public static void main(String[] args) {
+    System.out.println("Hello World");
+  }
+}
+
+```
+
 ```javascript
 const kittn = require('kittn');
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
     {{ partial "js.html" . }}
     {{ partial "hook_head_end.html" . }}
 </head>
-<body class="index" data-languages='[{{ partial "site_languages.html" . }}]' {{ with .Site.Params.language_tabs  }}{{ range $i,$e := . }} data-with{{ $e.key }}='[{{ printf " %q " $e.key }}{{ if isset $e "otherlangs" }}, {{ printf " %q " $e.otherlangs }}{{ end }}]'{{ end }}{{ end }}>
+<body class="index" data-languages='[{{ partial "site_languages.html" . }}]' {{ with .Site.Params.language_tabs  }}{{ range $i,$e := . }} data-with{{ $e.name }}='[{{ printf " %q " $e.key }}{{ if isset $e "otherlangs" }}, {{ printf " %q " $e.otherlangs }}{{ end }}]'{{ end }}{{ end }}>
     <a href="#" id="nav-button">
         <span>
         NAV

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
     {{ partial "js.html" . }}
     {{ partial "hook_head_end.html" . }}
 </head>
-<body class="index" data-languages='[{{ partial "site_languages.html" . }}]'>
+<body class="index" data-languages='[{{ partial "site_languages.html" . }}]' {{ with .Site.Params.language_tabs  }}{{ range $i,$e := . }} data-with{{ $e.key }}='[{{ printf " %q " $e.key }}{{ if isset $e "otherlangs" }}, {{ printf " %q " $e.otherlangs }}{{ end }}]'{{ end }}{{ end }}>
     <a href="#" id="nav-button">
         <span>
         NAV

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
     {{ partial "js.html" . }}
     {{ partial "hook_head_end.html" . }}
 </head>
-<body class="index" data-languages="{{ with .Site.Params.language_tabs  }}[{{ range $i,$e := . }}{{- if $i -}}, {{ end -}}{{ printf " %q " $e.key }}{{end}}]{{ end }}">
+<body class="index" data-languages='[{{ partial "site_languages.html" . }}]'>
     <a href="#" id="nav-button">
         <span>
         NAV

--- a/layouts/partials/site_languages.html
+++ b/layouts/partials/site_languages.html
@@ -1,0 +1,12 @@
+{{ $string := "" }}
+{{ with .Site.Params.language_tabs  }}
+{{ $scratch := newScratch }}
+  {{ range $i,$e := . }}
+     {{ $scratch.SetInMap "languages" $e.key ( printf " %q " $e.key ) }}
+     {{ if isset $e "otherlangs" }}
+       {{ $scratch.SetInMap "languages" $e.otherlangs ( printf " %q " $e.otherlangs ) }}
+     {{ end }}
+  {{ end }}
+  {{ $string = (delimit ($scratch.Get "languages") ", "  )}}
+{{ end }}
+{{ return $string }}


### PR DESCRIPTION
Fix #54 

I realize this PR is not very elegant yet.

The body data attributes are now a list of all languages including "otherlangs", and a list by tab of languages to go with the main language.

Problem, at the moment it only works after refreshing the page, because of how I access the data attribute "data-with<language>". Any idea how to improve this? :grimacing: