### PR TITLE
Enable language specific Markdown content

### DIFF
--- a/assets/js/slate/app/_lang.js
+++ b/assets/js/slate/app/_lang.js
@@ -37,7 +37,7 @@ under the License.
       $(".lang-specific." + languages[i]).hide();
     }
     $(codeSelectorPrefix + language).parentsUntil(".highlight").show();
-    $(".lang-specific." + language).parentsUntil(".highlight").show();
+    $(".lang-specific." + language).show();
 
     // scroll to the new location of the position
     if ($(window.location.hash).get(0)) {

--- a/assets/scss/slate/_variables.scss
+++ b/assets/scss/slate/_variables.scss
@@ -7,6 +7,14 @@
   }
 }
 
+// prevent clearing of lang-specific divs
+div.lang-specific {
+  clear:none !important;
+}
+div.lang-specific:after {
+  clear:none;
+}
+
 // BACKGROUND COLORS
 ////////////////////
 $nav-bg: #2E3336 !default;

--- a/layouts/shortcodes/lang.html
+++ b/layouts/shortcodes/lang.html
@@ -1,1 +1,1 @@
-<div class="lang-specific {{ .Get 0 }} content">{{ .Inner | markdownify }}</div>
+<div class="lang-specific {{ .Get 0 }} content"><area/>{{ .Inner | markdownify }}</div>

--- a/layouts/shortcodes/lang.html
+++ b/layouts/shortcodes/lang.html
@@ -1,0 +1,1 @@
+<div class="lang-specific {{ .Get 0 }} content">{{ .Inner | markdownify }}</div>


### PR DESCRIPTION
/kind bug

**What this PR does**:

* Fixes `app/_lang.js` according to upstream https://github.com/slatedocs/slate/commit/8cba35231544fc17cc5c584e56ccb41f3547c7af
* Introduces a new Hugo shortcode (`lang`) to incorporate that functionality

**Why we need it**:

The new shortcode enables entire Markdown blocks to be language specific.
This could be particularly useful for setup sections, multi-language tabs or
generally content that differs for each language.

**Which issue(s) this PR fixes**:

Fixes #54 

**Additional documentation**:

    {{< lang python >}}
    ## Install Kittens from PyPI:

    ```
    sudo pip install kittn
    ```

    > If you are using a virtualenv, you may want to avoid using `sudo`:

    ```
    pip install kittn
    ```

    **Note**: These installation steps assume that you are on a Linux environment.
    {{< /lang >}}

Generates the following only while the *Python* (`python`) tab is selected.

![usage](https://user-images.githubusercontent.com/24586902/84086868-8c0b8880-a9f1-11ea-81ff-783e899107b4.png)
