### PR TITLE
Allow unsafe rendering in config, in order to make hugo render the html tags

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -19,6 +19,8 @@ defaultContentLanguage = "en"
   [markup.goldmark]
     [markup.goldmark.parser]
       autoHeadingIDType = "github-ascii"
+    [markup.goldmark.renderer]
+        unsafe = true
 
 [module]
 [module.hugoVersion]


### PR DESCRIPTION
Fixes #57 