### PR TITLE
Add support up to 3 levels deep left submenu

### DIFF
--- a/assets/scss/slate/_variables.scss
+++ b/assets/scss/slate/_variables.scss
@@ -7,6 +7,11 @@
   }
 }
 
+.toc-wrapper .toc-h3 {
+  padding-left: 50px;
+  font-size: 12px;
+}
+
 // BACKGROUND COLORS
 ////////////////////
 $nav-bg: #2E3336 !default;

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -30,6 +30,7 @@ path="github.com/bep/empty-hugo-module"
 
 [params]
 search = true
+maxMenuDepth = 3 # (optional) available options are: 1, 2, or 3 (default: 2)
   
 # Configure the language example tabs.
 [[params.language_tabs]]

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/bep/empty-hugo-module v1.0.0 // indirect
-	github.com/jquery/jquery-dist v0.0.0-20190501211928-15bc73803f76 // indirect
-	github.com/olivernn/lunr.js v2.3.8+incompatible // indirect
-	github.com/slatedocs/slate v2.3.1+incompatible // indirect
+	github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f // indirect
+	github.com/olivernn/lunr.js v2.3.9+incompatible // indirect
+	github.com/slatedocs/slate v2.9.2+incompatible // indirect
 )

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,9 +1,8 @@
 github.com/bep/empty-hugo-module v1.0.0 h1:aYc9RWea644CdYjg9zCy8nkVF4KjC3fwhUTvvcXXg8s=
 github.com/bep/empty-hugo-module v1.0.0/go.mod h1:whohinbSjMoFi/Skivj9kvdPs1tEgzYpZ4rXoQk/0/I=
-github.com/jquery/jquery-dist v0.0.0-20190501211928-15bc73803f76 h1:j+Kzn/FdSZMPCfz6nZAJUU2+DBH0LPZU/Cmq3ZhBoRA=
-github.com/jquery/jquery-dist v0.0.0-20190501211928-15bc73803f76/go.mod h1:/lTfttEqFU0GWTaOOMIeNTzLGQ7yTIgyzjtkS/pYIoc=
-github.com/jquery/jquery-dist v0.0.0-20191202185020-55b7d19f7bf1 h1:5J/Uu1ow4Ldq50ZaN8fq9qkqDq6UJdjSoHy6oVBBSR4=
-github.com/jquery/jquery-dist v0.0.0-20191202185020-55b7d19f7bf1/go.mod h1:/lTfttEqFU0GWTaOOMIeNTzLGQ7yTIgyzjtkS/pYIoc=
-github.com/olivernn/lunr.js v2.3.8+incompatible h1:t9qfO9qpBCSEhjnvTHQtfOA8Ggwnvn5Y1JWFalyoPl0=
-github.com/olivernn/lunr.js v2.3.8+incompatible/go.mod h1:yEkQ1DUSMtNsn8n2CqvQXZd0ErWPEG8g9QRmblR+KS8=
-github.com/slatedocs/slate v2.3.1+incompatible/go.mod h1:n698aXLkExWIlF7prJey0Kq6wlKIKvj/stVb5oouZDM=
+github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f h1:VrcFwwDo/nKErNIKmp//iOGu7DlRkBTeW//hN7tl7SU=
+github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f/go.mod h1:/lTfttEqFU0GWTaOOMIeNTzLGQ7yTIgyzjtkS/pYIoc=
+github.com/olivernn/lunr.js v2.3.9+incompatible h1:eH8iBnjlR4mwlYDdNuqy9PCNLjp2bEs6aoNnTSaccx0=
+github.com/olivernn/lunr.js v2.3.9+incompatible/go.mod h1:yEkQ1DUSMtNsn8n2CqvQXZd0ErWPEG8g9QRmblR+KS8=
+github.com/slatedocs/slate v2.9.2+incompatible h1:PnIMTR1S7pE6tImIjF6ny9UaRrt6fukM93lwUwJPtjw=
+github.com/slatedocs/slate v2.9.2+incompatible/go.mod h1:n698aXLkExWIlF7prJey0Kq6wlKIKvj/stVb5oouZDM=

--- a/exampleSite/resources/_gen/assets/scss/scss/slate/print.css.scss_c14439616ffbc3ae1827507340d6c08b.content
+++ b/exampleSite/resources/_gen/assets/scss/scss/slate/print.css.scss_c14439616ffbc3ae1827507340d6c08b.content
@@ -360,12 +360,16 @@ th {
 .content > div.highlight {
   clear: none; }
 
-.content h1, .content h2, .content h3, .content h4, body {
+.toc-wrapper .toc-h3 {
+  padding-left: 50px;
+  font-size: 12px; }
+
+body, .content h3, .content h4, .content h2, .content h1 {
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 14px;
   font-weight: 400; }
 
-.content h1, .content h2, .content h3, .content h4 {
+.content h3, .content h4, .content h2, .content h1 {
   font-weight: 700; }
 
 .content pre, .content code {
@@ -384,7 +388,7 @@ th {
   font-weight: normal;
   font-style: normal; }
 
-.content aside.warning:before, .content aside.notice:before, .content aside.success:before {
+.content aside.success:before, .content aside.notice:before, .content aside.warning:before {
   font-family: 'slateeee';
   speak: none;
   font-style: normal;
@@ -483,5 +487,9 @@ under the License.
     vertical-align: middle;
     padding-right: 0.5em;
     font-size: 14px; }
+
+@media print {
+  .copy-clipboard {
+    display: none; } }
 
 /*# sourceMappingURL=print.css.map */

--- a/exampleSite/resources/_gen/assets/scss/scss/slate/screen.css.scss_d18af36970f1f09b308ef20ee65e3a03.content
+++ b/exampleSite/resources/_gen/assets/scss/scss/slate/screen.css.scss_d18af36970f1f09b308ef20ee65e3a03.content
@@ -360,15 +360,19 @@ th {
 .content > div.highlight {
   clear: none; }
 
-.content h1, .content h2, .content h3, .content h4, .content h5, .content h6, html, body {
+.toc-wrapper .toc-h3 {
+  padding-left: 50px;
+  font-size: 12px; }
+
+html, body, .content h3, .content h4, .content h5, .content h6, .content h2, .content h1 {
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 14px;
   font-weight: 400; }
 
-.content h1, .content h2, .content h3, .content h4, .content h5, .content h6 {
+.content h3, .content h4, .content h5, .content h6, .content h2, .content h1 {
   font-weight: 700; }
 
-.content code, .content pre {
+.content pre, .content code {
   font-family: Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, serif;
   font-size: 12px;
   line-height: 1.5; }
@@ -384,7 +388,7 @@ th {
   font-weight: normal;
   font-style: normal; }
 
-.content aside.warning:before, .content aside.notice:before, .content aside.success:before, .toc-wrapper > .search:before {
+.toc-wrapper > .search:before, .content aside.success:before, .content aside.notice:before, .content aside.warning:before {
   font-family: 'slateeee';
   speak: none;
   font-style: normal;
@@ -596,12 +600,13 @@ html, body {
     border-bottom: 5px solid #002642; }
 
 .lang-selector {
+  display: flex;
   background-color: #1E2224;
   width: 100%;
-  font-weight: bold; }
+  font-weight: bold;
+  overflow-x: auto; }
   .lang-selector a {
-    display: block;
-    float: left;
+    display: inline;
     color: #fff;
     text-decoration: none;
     padding: 0 10px;
@@ -727,6 +732,9 @@ html, body {
     border: 1px solid #F7E633;
     background: linear-gradient(to top left, #F7E633 0%, #F1D32F 100%); }
 
+.content > div.highlight {
+  clear: none; }
+
 .content pre, .content blockquote {
   background-color: #1E2224;
   color: #fff;
@@ -785,5 +793,16 @@ html, body {
 
 .highlight, .highlight .w {
   background-color: #1E2224; }
+
+.copy-clipboard {
+  float: right;
+  fill: #9DAAB6;
+  cursor: pointer;
+  opacity: 0.4;
+  height: 18px;
+  width: 18px; }
+
+.copy-clipboard:hover {
+  opacity: 0.8; }
 
 /*# sourceMappingURL=screen.css.map */

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bep/docuapi
 go 1.12
 
 require (
-	github.com/jquery/jquery-dist v0.0.0-20190501211928-15bc73803f76 // indirect
-	github.com/olivernn/lunr.js v2.3.8+incompatible // indirect
-	github.com/slatedocs/slate v2.3.1+incompatible // indirect
+	github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f // indirect
+	github.com/olivernn/lunr.js v2.3.9+incompatible // indirect
+	github.com/slatedocs/slate v2.9.2+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
-github.com/jquery/jquery-dist v0.0.0-20190501211928-15bc73803f76 h1:j+Kzn/FdSZMPCfz6nZAJUU2+DBH0LPZU/Cmq3ZhBoRA=
-github.com/jquery/jquery-dist v0.0.0-20190501211928-15bc73803f76/go.mod h1:/lTfttEqFU0GWTaOOMIeNTzLGQ7yTIgyzjtkS/pYIoc=
-github.com/jquery/jquery-dist v0.0.0-20191202185020-55b7d19f7bf1 h1:5J/Uu1ow4Ldq50ZaN8fq9qkqDq6UJdjSoHy6oVBBSR4=
-github.com/jquery/jquery-dist v0.0.0-20191202185020-55b7d19f7bf1/go.mod h1:/lTfttEqFU0GWTaOOMIeNTzLGQ7yTIgyzjtkS/pYIoc=
-github.com/olivernn/lunr.js v2.3.8+incompatible h1:t9qfO9qpBCSEhjnvTHQtfOA8Ggwnvn5Y1JWFalyoPl0=
-github.com/olivernn/lunr.js v2.3.8+incompatible/go.mod h1:yEkQ1DUSMtNsn8n2CqvQXZd0ErWPEG8g9QRmblR+KS8=
-github.com/slatedocs/slate v2.3.1+incompatible/go.mod h1:n698aXLkExWIlF7prJey0Kq6wlKIKvj/stVb5oouZDM=
+github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f h1:VrcFwwDo/nKErNIKmp//iOGu7DlRkBTeW//hN7tl7SU=
+github.com/jquery/jquery-dist v0.0.0-20210302171154-e786e3d9707f/go.mod h1:/lTfttEqFU0GWTaOOMIeNTzLGQ7yTIgyzjtkS/pYIoc=
+github.com/olivernn/lunr.js v2.3.9+incompatible h1:eH8iBnjlR4mwlYDdNuqy9PCNLjp2bEs6aoNnTSaccx0=
+github.com/olivernn/lunr.js v2.3.9+incompatible/go.mod h1:yEkQ1DUSMtNsn8n2CqvQXZd0ErWPEG8g9QRmblR+KS8=
+github.com/slatedocs/slate v2.9.2+incompatible h1:PnIMTR1S7pE6tImIjF6ny9UaRrt6fukM93lwUwJPtjw=
+github.com/slatedocs/slate v2.9.2+incompatible/go.mod h1:n698aXLkExWIlF7prJey0Kq6wlKIKvj/stVb5oouZDM=

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,6 +6,12 @@
 
 {{ define "toc" }}
     <ul id="toc" class="toc-list-h1">
+        {{ $maxDepth := 0 }}
+        {{ with $.Site.Params.maxMenuDepth }}
+            {{ $maxDepth = . }}
+        {{ else }}
+            {{ $maxDepth = 2 }}
+        {{ end }}
         {{ $headers := slice }}
         {{ with .Site.RegularPages  }}
             {{ $headers = partial "funcs/toc_from_pages" . }}
@@ -13,14 +19,23 @@
         {{ range $headers }}
             <li>
                 <a href="#{{ .id }}" class="toc-h{{ .level }} toc-link" data-title="{{ .title }}">{{ .title }}</a>
-                {{if .sub }}
+                {{ if and (ge $maxDepth 2) .sub }}
                     <ul class="toc-list-h2">
-                        {{range .sub}}
-                            <li><a href="#{{ .id }}" class="toc-h{{ .level }} toc-link" data-title="{{ .title }}">{{ .title }}</a></li>
-                        {{end}}
+                        {{ range .sub }}
+                            <li>
+                                <a href="#{{ .id }}" class="toc-h{{ .level }} toc-link" data-title="{{ .title }}">{{ .title }}</a>
+                                {{ if and (ge $maxDepth 3) .sub }}
+                                    <ul class="toc-list-h3">
+                                        {{ range .sub }}
+                                            <li><a href="#{{ .id }}" class="toc-h{{ .level }} toc-link" data-title="{{ .title }}">{{ .title }}</a></li>
+                                        {{ end }}
+                                    </ul>
+                                {{ end }}
+                            </li>
+                        {{ end }}
                     </ul>
-                {{end}}
+                {{ end }}
             </li>
-        {{end}}
+        {{ end }}
     </ul>
 {{ end }}

--- a/layouts/partials/funcs/toc_from_pages.html
+++ b/layouts/partials/funcs/toc_from_pages.html
@@ -5,30 +5,53 @@
 {{ end }}
 
 {{ $toc := slice }}
-{{ $previousH1 := dict }}
+
+{{ $previousH1 := dict}}
+{{ $previousH2 := dict}}
 {{ $previousLevel := 0 }}
+
 {{ $h2s := slice }}
+{{ $h3s := slice }}
 
 {{ range $combined }}
     {{ $level := int (substr . 2 1) }}
-    {{ if le $level 2 }}
+    {{ if le $level 3 }}
         {{ $idTitle := split (. | replaceRE "<h\\d id=\"(.*?)\">(.*)</h\\d>" "$1|$2") "|" }} 
         {{ $item := dict "level" $level "id" (index $idTitle 0) "title" (index $idTitle 1) }}
+
         {{ if eq $level 1 }}
             {{ if ne $previousLevel 0 }}
+                {{ if or (eq $previousLevel 2) (eq $previousLevel 3) }}
+                    {{ $tocItem := merge $previousH2 (dict "sub" $h3s) }}
+                    {{ $h2s = $h2s | append $tocItem }}
+                    {{ $h3s = slice }}
+                {{ end }}
+
                 {{ $tocItem := merge $previousH1 (dict "sub" $h2s) }}
                 {{ $toc = $toc | append $tocItem }}
                 {{ $h2s = slice }}
-            {{end}}
+                {{ $previousH2 = slice }}
+            {{ end }}
             {{ $previousH1 = $item }}
         {{ else }}
-            {{ $h2s = $h2s | append $item }}
+            {{ if eq $level 2 }}
+                {{ if and (ne $previousLevel 1) (ne $previousLevel 2) }}
+                    {{ $tocItem := merge $previousH2 (dict "sub" $h3s) }}
+                    {{ $h2s = $h2s | append $tocItem }}
+                    {{ $h3s = slice }}
+                {{ end }}
+                {{ $previousH2 = $item }}
+            {{ else }}
+                {{ $h3s = $h3s | append $item }}
+            {{ end }}
         {{ end }}
         {{ $previousLevel = $level }}
     {{ end }}
 {{ end }}
+
 {{ if ne $previousLevel 0 }}
     {{ $item := merge $previousH1 (dict "sub" $h2s) }}
     {{ $toc = $toc | append $item }}
 {{ end }}
+
 {{ return $toc }}


### PR DESCRIPTION
Add support up to 3 levels deep for submenu:

```text
H1
    H2
    H2
        H3
        H3
    H2
H1
    H2
...
```

`maxMenuDepth` is added to parameters which is optional and defaults
to 2 if empty or not found. This will control the depth for submenu
items to be rendered for left menu table of contents.

Fixes #37 