### PR TITLE
Fix TOC rendering issues

### DIFF
--- a/exampleSite/content/errors.md
+++ b/exampleSite/content/errors.md
@@ -10,6 +10,7 @@ title: Errors
 
 The Kittn API uses the following error codes:
 
+## 4xx
 
 Error Code | Meaning
 ---------- | -------
@@ -22,5 +23,10 @@ Error Code | Meaning
 410 | Gone -- The kitten requested has been removed from our servers
 418 | I'm a teapot
 429 | Too Many Requests -- You're requesting too many kittens! Slow down!
+
+## 5xx
+
+Error Code | Meaning
+---------- | -------
 500 | Internal Server Error -- We had a problem with our server. Try again later.
 503 | Service Unavailable -- We're temporarially offline for maintanance. Please try again later.

--- a/layouts/partials/funcs/toc_from_pages.html
+++ b/layouts/partials/funcs/toc_from_pages.html
@@ -40,6 +40,9 @@
                     {{ $h2s = $h2s | append $tocItem }}
                     {{ $h3s = slice }}
                 {{ end }}
+                {{ if eq $previousLevel 2 }}
+                    {{ $h2s = $h2s | append $previousH2 }}
+                {{ end }}
                 {{ $previousH2 = $item }}
             {{ else }}
                 {{ $h3s = $h3s | append $item }}
@@ -50,6 +53,9 @@
 {{ end }}
 
 {{ if ne $previousLevel 0 }}
+    {{ $tocItem := merge $previousH2 (dict "sub" $h3s) }}
+    {{ $h2s = $h2s | append $tocItem }}
+
     {{ $item := merge $previousH1 (dict "sub" $h2s) }}
     {{ $toc = $toc | append $item }}
 {{ end }}


### PR DESCRIPTION
While rendering TOC, some items were lost. For example:

- if last h1 has some children or grand children
- if any h1 has multiple h2 (without any h3)

Fixes #70 