### PR TITLE
Simple exampleSite setup

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,5 +1,3 @@
-theme = "docuapi"
-themesdir = "../.."
 languageCode = "en-us"
 baseurl = "https://docuapi.netlify.com/"
 title = "DocuAPI Example Site"
@@ -25,8 +23,8 @@ defaultContentLanguage = "en"
 [module]
 [module.hugoVersion]
 [[module.imports]]
-# We include the theme by "../.." above, but we need one module import for Hugo to detect us as a Hugo Module.
-path="github.com/bep/empty-hugo-module"
+# This is replaced in go.mod to point to the directory above.
+path="github.com/bep/docuapi/v2"
 
 [params]
 search = true

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -2,9 +2,6 @@ module github.com/bep/docuapi/exampleSite
 
 go 1.16
 
-require (
-	github.com/bep/empty-hugo-module v1.0.0 // indirect
-	github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.500.100 // indirect
-	github.com/olivernn/lunr.js v2.3.9+incompatible // indirect
-	github.com/slatedocs/slate v2.9.2+incompatible // indirect
-)
+require github.com/bep/docuapi/v2 v2.0.4 // indirect
+
+replace github.com/bep/docuapi/v2 => ../

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,7 +1,5 @@
-github.com/bep/empty-hugo-module v1.0.0 h1:aYc9RWea644CdYjg9zCy8nkVF4KjC3fwhUTvvcXXg8s=
-github.com/bep/empty-hugo-module v1.0.0/go.mod h1:whohinbSjMoFi/Skivj9kvdPs1tEgzYpZ4rXoQk/0/I=
-github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.401.201 h1:rIBco2i/51nTPbi7pHUvwBwznCddMOsp/9pR2veAPx8=
-github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.401.201/go.mod h1:WWQxcmPs5Xy3xDgi29ipkmZT6NKVb3bsqyCDTY3eYYY=
+github.com/bep/docuapi/v2 v2.0.4 h1:TU6CzjdfiWI+D/d911r8ZQG7R8h64ayEaC6iWNbJ/NQ=
+github.com/bep/docuapi/v2 v2.0.4/go.mod h1:hoeibCSjXWJ/fLOwPSo8WZbgl5EO3zQjS/nrAs2v2Ro=
 github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.500.100 h1:yIymGxglvwr9Guhk7cr9VoMQ3IgLLJ0E4PKcKCg+kJY=
 github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.500.100/go.mod h1:WWQxcmPs5Xy3xDgi29ipkmZT6NKVb3bsqyCDTY3eYYY=
 github.com/olivernn/lunr.js v2.3.9+incompatible h1:eH8iBnjlR4mwlYDdNuqy9PCNLjp2bEs6aoNnTSaccx0=


### PR DESCRIPTION
Use a replace directive in exampleSite/go.mod to point to the directory above instead of the themesDir workaround it replaces. This should make it more robust and be the same setup as people using this theme for real projects.
