### PR TITLE
Make the top search listing clickable

### DIFF
--- a/assets/js/controllers/search-lunr.js
+++ b/assets/js/controllers/search-lunr.js
@@ -72,6 +72,7 @@ export function newSearchController() {
 
 				return {
 					title: elem.innerText,
+					id: item.ref,
 				};
 			});
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -46,7 +46,7 @@
             x-transition.duration.700ms>
             <template x-for="item in results">
               <li>
-                <a x-text="item.title"></a>
+                <a x-text="item.title" :href="`#${item.id}`"></a>
               </li>
             </template>
           </ul>


### PR DESCRIPTION
This is probably how it always have worked, but the main search listing looks like somethig that
should be clicked on.
