### PR TITLE
Mitigates layout shift on switching programming language tab

### DIFF
--- a/assets/js/controllers/lang.js
+++ b/assets/js/controllers/lang.js
@@ -11,19 +11,29 @@ const toggleCodeblockVisibility = function (lang, visible) {
 export function newLangController() {
 	return {
 		tabs: [],
+        contentChildren: [],
 		changeLanguage: function (index) {
 			debug('changeLanguage', index);
+            const anchor = this.contentChildren.find(el => {
+                return el.getBoundingClientRect().top > 0
+            })
+            const anchorValue = anchor.getBoundingClientRect().top;
 			for (let i = 0; i < this.tabs.length; i++) {
 				let isActive = i === index;
 				this.tabs[i].active = isActive;
 
 				toggleCodeblockVisibility(this.tabs[i].key, isActive);
 			}
+            const updatedAnchorElementValue = anchor.getBoundingClientRect().top;
+            anchorValue !== updatedAnchorElementValue && window.scrollBy(0, updatedAnchorElementValue);
 		},
 		initLangs: function (tabs) {
 			debug('initLangs', tabs);
 			tabs[0].active = true;
 			this.tabs = tabs;
+            this.contentChildren = Array.from(document.querySelector('.page-wrapper .content').children)
+                .filter(el => el.tagName !== 'BLOCKQUOTE')
+                .filter(el => !el.classList.contains('highlight'))
 
 			return this.$nextTick(() => {
 				this.changeLanguage(0);


### PR DESCRIPTION
Mitigates the layout shift pointed in https://github.com/bep/docuapi/issues/95 

The programmatic scrolling triggered by layout shifts targets the direct children of the `.content` container element, thus there's instances where a layout shift is still present, although keeping what would be a visually relevant node as the anchor of the behavior. It is a compromise to avoid walking large nested element trees in large documents.